### PR TITLE
Redo Exs 1-3 in more quanteda-like way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+.Rproj.user
+Text_as_Data.Rproj
+

--- a/recitation_1.R
+++ b/recitation_1.R
@@ -5,68 +5,69 @@
 
 
 ## be sure to install the latest version from GitHub, using dev branch:
-devtools::install_github("quanteda", username="kbenoit", dependencies=TRUE, ref="dev")
+devtools::install_github("kbenoit/quanteda")
 ## and quantedaData
-devtools::install_github("quantedaData", username="kbenoit")
+devtools::install_github("kbenoit/quantedaData")
 
 library(quanteda)
-library(quantedaData)
+
 ##start with a short document
 sampletxt <- "The police with their policing strategy instituted a policy of general 
 iterations at the Data Science Institute."
 
 #Let's tokenize
-tokens<-tokenize(sampletxt)
+tokens <- tokenize(sampletxt)
 ?tokenize
 
-tokens<-tokenize(sampletxt, removePunct=TRUE)
+tokens <- tokenize(sampletxt, removePunct=TRUE)
 
 
 ## stemming examples
 
-stems<-wordstem(tokens)
+stems <- wordstem(tokens)
 ?wordstem
 
 # vector representations
 
-data("SOTUCorpus")
+data("SOTUCorpus", package = "quantedaData")
 
-speeches<-data.frame(SOTUCorpus$documents)
 
-last_speech_text<-speeches$texts[230]
+last_speech_text <- SOTUCorpus[ndoc(SOTUCorpus)]
+# same as 
+last_speech_text <- texts(SOTUCorpus)[ndoc(SOTUCorpus)]
 
-obama_dfm<-dfm(last_speech_text)
+obama_dfm <- dfm(last_speech_text)
 ?dfm
 
 ##stopwords example
 
 stopwords("english")
 
-obama_dfm<-dfm(last_speech_text, ignoredFeatures = stopwords("english"))
+obama_dfm <- dfm(last_speech_text, ignoredFeatures = stopwords("english"))
 
 
 ###full matrix of all speeches
 
-full_dfm<-dfm(speeches$texts, ignoredFeatures = stopwords("english"))
+full_dfm <- dfm(SOTUCorpus, ignoredFeatures = stopwords("english"))
 
 topfeatures(full_dfm)
 
-plot(full_dfm)
+plot(full_dfm, min.freq = 30)
 
 ##weighting--tfidf
 
 
-weighted<-tfidf(full_dfm)
+weighted_dfm <- tfidf(full_dfm)
 
 
-topfeatures(weighted)
+topfeatures(weighted_dfm)
 
 
 ##Think about what this means!
 
 
 
-normalized<-tfidf(full_dfm, normalize=TRUE)
+normalized <- tfidf(full_dfm, normalize=TRUE)
 
 topfeatures(normalized)
 
@@ -83,9 +84,10 @@ colloc <- collocations(last_speech_text)
 
 
 ## remove any collocations containing a word in the stoplist
-isStopwordList <- lapply(colloc$word1, `%in%`, stopwords("english"))
-stopwordindex <- which(colloc$word1 %in% stopwords("english")| colloc$word2 %in% stopwords("english"))
-colloc[-stopwordindex]  # collocations not containing stopwords
+# isStopwordList <- lapply(colloc$word1, `%in%`, stopwords("english"))
+# stopwordindex <- which(colloc$word1 %in% stopwords("english")| colloc$word2 %in% stopwords("english"))
+# colloc[-stopwordindex]  # collocations not containing stopwords
+removeFeatures(colloc, stopwords("english"))
 
 
 ##now let's take a little look at regular expressions
@@ -95,18 +97,19 @@ colloc[-stopwordindex]  # collocations not containing stopwords
 
 ?regex
 
-s_index<-grep(" s ", speeches$texts )
+s_index <- grep(" s ", texts(SOTUCorpus))
 
 ?grep
 
-grep(" s ", speeches$texts, value=TRUE )
+# this returns every speech that contains " s "
+grep(" s ", texts(SOTUCorpus), value=TRUE)
 
 
-s_index<-grep(" s ", speeches$texts )
+s_index <- grep(" s ", texts(SOTUCorpus))
 
 
 
-no_s<-gsub(" s ", "",  speeches$texts[s_index] )
+no_s <- gsub(" s ", "",  SOTUCorpus[s_index])
 
 
 

--- a/recitation_2.R
+++ b/recitation_2.R
@@ -5,16 +5,11 @@
 
 
 ## be sure to install the latest version from GitHub, using dev branch:
-devtools::install_github("quanteda", username="kbenoit", dependencies=TRUE, ref="dev")
+devtools::install_github("kbenoit/quanteda")
 ## and quantedaData
-devtools::install_github("quantedaData", username="kbenoit")
+devtools::install_github("kbenoit/quantedaData")
 
 library(quanteda)
-library(quantedaData)
-##load data
-data(inaugCorpus)
-
-
 
 
 ## demonstrate Heap's law
@@ -25,16 +20,19 @@ data(inaugCorpus)
 # T = number of tokens
 # k, b are constants
 
-tokens<-tokenize(inaugCorpus, removePunct=TRUE) 
-Tee<-lapply(tokens,  length )
-Tee<-sum(unlist(Tee))
+tokens <- tokenize(inaugCorpus, removePunct=TRUE) 
+Tee <- lengths(tokens)
+Tee <- sum(Tee)
 
 mydfm <- dfm(inaugCorpus)
-M<-length(mydfm@Dimnames$features)
+### nooooo
+M <- length(mydfm@Dimnames$features)
+## yes
+M <- nfeature(mydfm)
 # Let's check using parameter values from MRS for a corpus with more than 100,000 tokens
 
-k<- 44
-b<-.49
+k <- 44
+b <- .49
 
 k * (Tee)^b
 
@@ -50,9 +48,9 @@ k * (Tee)^b
 
 
 
-inaugCorpus$document$texts[1]
+inaugCorpus[1]
 
-inaugCorpus$document$texts[57]
+inaugCorpus[57]
 
 ## demonstrate Zipf's law
 
@@ -76,7 +74,7 @@ confint(regression)
 
 ## let's look at co-locations 
 
-last_speech_text<-inaugCorpus$document$texts[57]
+last_speech_text <- inaugCorpus[57]
 
 collocations(last_speech_text)
 
@@ -86,9 +84,10 @@ collocations(last_speech_text, size=3)
 ## remove any collocations containing a word in the stoplist
 colloc <- collocations(last_speech_text)
 
-isStopwordList <- lapply(colloc$word1, `%in%`, stopwords("english"))
-stopwordindex <- which(colloc$word1 %in% stopwords("english")| colloc$word2 %in% stopwords("english"))
-colloc[-stopwordindex]  # collocations not containing stopwords
+# isStopwordList <- lapply(colloc$word1, `%in%`, stopwords("english"))
+# stopwordindex <- which(colloc$word1 %in% stopwords("english")| colloc$word2 %in% stopwords("english"))
+# colloc[-stopwordindex]  # collocations not containing stopwords
+removeFeatures(colloc, stopwords("english"))
 
 
 ##that's not all we can do with collocations
@@ -112,8 +111,8 @@ kwic(inaugCorpus, "slavery", 3)
 # x * y = |x||y|cos
 # cos = x*y/|x||y|
 
-x<-c(1,2,3)
-y<-c(1,2,3)
+x <- c(1,2,3)
+y <- c(1,2,3)
 
 ##define the norm
 norm_vec <- function(x) sqrt(sum(x^2))
@@ -123,18 +122,18 @@ x %*% y / (norm_vec(x)*norm_vec(y))
 
 
 #what if they're different
-a<-c(1,2,3)
-b<-c(1,2,4000)
+a <- c(1,2,3)
+b <- c(1,2,4000)
 
 a %*% b / (norm_vec(a)*norm_vec(b))
 
 
 ##let's do it with texts
-last_speech_text<-inaugCorpus$document$texts[57]
-first_speech_text<-inaugCorpus$document$texts[1]
+last_speech_text <- inaugCorpus[ndoc(inaugCorpus)]
+first_speech_text <- inaugCorpus[1]
 
 ##make a dfm of these two
-inaug_dfm<-dfm(c(last_speech_text, first_speech_text),ignoredFeatures = stopwords("english"),    stem = TRUE)
+inaug_dfm <- dfm(c(last_speech_text, first_speech_text), ignoredFeatures = stopwords("english"), stem = TRUE)
 
 #calculate similarity
 tmp <- similarity(inaug_dfm, margin = "documents")
@@ -142,7 +141,7 @@ tmp <- similarity(inaug_dfm, margin = "documents")
 as.matrix(tmp)
 
 ##Let's see how stopwords/stemming affect this
-inaug_dfm<-dfm(c(last_speech_text, first_speech_text))
+inaug_dfm <- dfm(c(last_speech_text, first_speech_text))
 
 #calculate similarity
 tmp <- similarity(inaug_dfm, margin = "documents")
@@ -153,7 +152,7 @@ as.matrix(tmp)
 
 
 ##make a dfm of a bunch
-inaug_dfm<-dfm(subset(inaugCorpus , Year > 1980),ignoredFeatures = stopwords("english"),    stem = TRUE)
+inaug_dfm <- dfm(subset(inaugCorpus , Year > 1980),ignoredFeatures = stopwords("english"), stem = TRUE)
 
 #calculate similarity
 tmp <- similarity(inaug_dfm, margin = "documents")

--- a/recitation_3.R
+++ b/recitation_3.R
@@ -12,7 +12,7 @@ library(quanteda)
 
 
 ##load in data
-data("iebudgetsCorpus", package = "quantedaData")
+data(iebudgetsCorpus, package = "quantedaData")
 
 
 df <- texts(iebudgetsCorpus)
@@ -114,6 +114,30 @@ cor(readability(iebudgetsCorpus, c("Flesch", "Dale.Chall", "SMOG", "Coleman.Liau
 
 
 ####Bootstrapping!
+
+# remove smaller parties
+iebudgetsCorpSub <- subset(iebudgetsCorpus, !(party %in% c("WUAG", "SOC", "PBPA" )))
+
+library(boot)
+bsReadabilityByGroup <- function(x, i, groups = NULL, measure = "Flesch")
+    readability(texts(x[i], groups = groups), measure)
+R <- 50
+
+# by party
+groups <- factor(iebudgetsCorpSub[["party"]])
+b <- boot(texts(iebudgetsCorpSub), bsReadabilityByGroup, strata = groups, R = R, groups = groups)
+colnames(b$t) <- names(b$t0)
+apply(b$t, 2, quantile, c(.025, .5, .975))
+
+# by year
+groups <- factor(iebudgetsCorpSub[["year"]])
+b <- boot(texts(iebudgetsCorpSub), bsReadabilityByGroup, strata = groups, R = R, groups = groups)
+colnames(b$t) <- names(b$t0)
+apply(b$t, 2, quantile, c(.025, .5, .975))
+
+## can get the SEs the same way, from b$t
+
+
 
 
 #Let's consider the different speeches by different parties/years, say we want to get standard errors on Flesch scores

--- a/recitation_3.R
+++ b/recitation_3.R
@@ -5,7 +5,6 @@
 
 
 library(quanteda)
-library(quantedaData)
 
 ##load data
 
@@ -13,47 +12,53 @@ library(quantedaData)
 
 
 ##load in data
-data("iebudgetsCorpus")
+data("iebudgetsCorpus", package = "quantedaData")
 
 
-df<-data.frame(iebudgetsCorpus$documents)
+df <- texts(iebudgetsCorpus)
 
 ## Lexical diversity measures
 
 # TTR 
-tokens<-tokenize(iebudgetsCorpus, removePunct=TRUE) 
+## might want toLower(iebudgetsCorpus)
+tokens <- tokenize(iebudgetsCorpus, removePunct=TRUE) 
 
-tokenz<-lapply(tokens,  length )
+# tokenz <- lapply(tokens, length)
+tokenz <- lengths(tokens)
 
-typez<-lapply(lapply(tokens,  unique ), length)
+# typez <- lapply(lapply(tokens,  unique ), length)
+typez <- ntype(tokens)
 
-TTRz<-mapply("/",typez,tokenz,SIMPLIFY = FALSE)
+#TTRz <- mapply("/", typez, tokenz, SIMPLIFY = FALSE)
 
-df$ttr<-unlist(TTRz)
-
+# df$ttr<-unlist(TTRz)
+ttr <- typez / tokenz
 
 
 ##basic plot
 
-plot(df$ttr)
-
+#plot(df$ttr)
+plot(ttr)
 
 ## 
 
-df$year<-as.numeric(df$year)
+#df$year<-as.numeric(df$year)
 
-aggregate(df$ttr, by=list(df$year), FUN=mean)
+#aggregate(df$ttr, by=list(df$year), FUN=mean)
+aggregate(ttr, by = list(iebudgetsCorpus[["year"]]), FUN = mean)
 
-table(df$year)
-
-
-aggregate(df$ttr, by=list(df$party), FUN=mean)
+# table(df$year)
 
 
+aggregate(ttr, by = list(iebudgetsCorpus[["party"]]), FUN = mean)
 
-table(df$party)
 
 
+#table(df$party)
+
+# another way:
+lexdiv(dfm(iebudgetsCorpus, groups = "year", verbose = FALSE))
+lexdiv(dfm(iebudgetsCorpus, groups = "party", verbose = FALSE))
 
 
 ##Let's think about if it matters
@@ -65,32 +70,36 @@ table(df$party)
 
 
 ##let's look at FRE
-df$read_FRE<-readability(df$texts, "Flesch")
+#df$read_FRE<-readability(df$texts, "Flesch")
+readability(iebudgetsCorpus, "Flesch")
 
+#aggregate(df$read_FRE, by=list(df$year), FUN=mean)
+readability(texts(iebudgetsCorpus, groups = "year"), "Flesch")
 
-aggregate(df$read_FRE, by=list(df$year), FUN=mean)
+#aggregate(df$read_FRE, by=list(df$party), FUN=mean)
+readability(texts(iebudgetsCorpus, groups = "party"), "Flesch")
 
-aggregate(df$read_FRE, by=list(df$party), FUN=mean)
 
 ##Dale-Chall measure
-df$read_DC<-readability(df$texts, "Dale.Chall")
+#df$read_DC<-readability(df$texts, "Dale.Chall")
+readability(iebudgetsCorpus, "Dale.Chall")
 
 
-aggregate(df$read_DC, by=list(df$year), FUN=mean)
+#aggregate(df$read_DC, by=list(df$year), FUN=mean)
+readability(texts(iebudgetsCorpus, groups = "year"), "Dale.Chall")
 
-aggregate(df$read_DC, by=list(df$party), FUN=mean)
+#aggregate(df$read_DC, by=list(df$party), FUN=mean)
+readability(texts(iebudgetsCorpus, groups = "party"), "Dale.Chall")
 
 ##let's look at all of em
 
-read<-readability(df$texts)
+#read<-readability(df$texts)
 
-cor(read$Flesch, read$Dale.Chall)
+cor(readability(iebudgetsCorpus, c("Flesch", "Dale.Chall", "SMOG", "Coleman.Liau", "Fucks")))
 
-cor(read$Flesch, read$SMOG)
+#cor(read$Flesch, read$SMOG)
 
-cor(read$Coleman.Liau, read$Dale.Chall)
-
-
+#cor(read$Coleman.Liau, read$Dale.Chall)
 
 
 
@@ -99,7 +108,9 @@ cor(read$Coleman.Liau, read$Dale.Chall)
 
 
 
-cor(read$Fucks, read$Dale.Chall)
+
+
+# cor(read$Fucks, read$Dale.Chall)
 
 
 ####Bootstrapping!
@@ -110,12 +121,12 @@ cor(read$Fucks, read$Dale.Chall)
 library(dplyr)
 
 ##initialize data frames
-year_FRE<-data.frame(matrix(ncol = 5, nrow = 100))
+year_FRE <- data.frame(matrix(ncol = 5, nrow = 100))
 
 
 #Let's filter out the parties with only one speech
 
-df<-filter(df, party != "WUAG" & party != "SOC"  & party != "PBPA" )
+df <- filter(df, party != "WUAG" & party != "SOC"  & party != "PBPA" )
 
 party_FRE<-data.frame(matrix(ncol = 6, nrow = 100))
 


### PR DESCRIPTION
I edited all but the bootstrapping at the end - will do that soon too. In general: Do not access object internals. For instance always use `texts(inaugCorpus)` instead of inaugCorpus$documents$texts. See my edits.
